### PR TITLE
Remove pynder submodule and install from Github instead

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "pynder"]
-	path = pynder
-	url = https://github.com/cjekel/pynder.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 install:
   - pip install flake8 pytest opencv-python
   - pip install . --no-cache-dir
+  - pip install git+git://github.com/cjekel/pynder
 before_script:
   - flake8 tindetheus/__init__.py
   - flake8 tindetheus/export_embeddings.py
@@ -14,7 +15,4 @@ before_script:
   - flake8 tindetheus/tinder_client.py
   - flake8 tindetheus/tindetheus_align.py
   - flake8 tindetheus/tindetheus.py
-  - cd pynder
-  - pip install .
-  - cd ..
 script: pytest -p no:warnings tests/tests.py

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ help-tindetheus:  ## Display this help.
 init-tindetheus: ## Download dependences.
 	@cd ${TINDETHEUS_ROOT} && \
 	[[ -d tinder ]] || mkdir tinder && \
-	[[ -d pynder/pynder ]] || git submodule update --init --recursive && \
 	if [[ ! -d .venv ]]; then \
 		python3 -m venv .venv; \
 		.venv/bin/pip install --upgrade -r requirements.txt; \

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ setuptools>=38.6.0
 tensorflow<2.0.0
 
 #pynder
-./pynder
+git+git://github.com/cjekel/pynder
 
 #tindetheus
 -e .


### PR DESCRIPTION
There are many benefits to this e.g.
* We can update the library with the latest changes from https://github.com/charliewolf/pynder without losing your changes
* The repo is less cluttered with code we're never going to change.
* Whatever issue the submodule was causing with the Docker (#21) in no longer an issues 
* No extra step. Just install the requirements.txt.

If you're happy with the change, I'll can update the documentation.